### PR TITLE
Fixed errors with modules outside of project (built in CRUD module)

### DIFF
--- a/src-compiler/GroovyCompiler.groovy
+++ b/src-compiler/GroovyCompiler.groovy
@@ -43,11 +43,13 @@ class GroovyCompiler {
 	static def getSourceFiles = { path, regex = /^[^.].*[.](groovy|java)$/ ->
 			
 		def list = []
-		path.eachFileRecurse(FileType.FILES, { f ->
-			if (f =~ regex) {
-				list << f
-			}
-		})
+		if(path.exists()) {
+			path.eachFileRecurse(FileType.FILES, { f ->
+				if (f =~ regex) {
+					list << f
+				}
+			})
+		}
 		return list
 	}
 


### PR DESCRIPTION
Hi Dave.

I've had some issues with groovy plugin and sources outside of project. It was throwing NPE when trying to refresh class in built in Play CRUD module.

I've changed updateJava so it uses absolute paths when removing prefixes and does not assume that all sources are in app folder.

Also fixed FileNotFound exception when there was some classpath entry that didn't exist in file system.

Bye,
Marek.
